### PR TITLE
Improved the e-mail explanation texts on the RegistrationPage

### DIFF
--- a/src/main/java/nl/knaw/dans/dccd/web/authn/RegistrationPage.properties
+++ b/src/main/java/nl/knaw/dans/dccd/web/authn/RegistrationPage.properties
@@ -16,7 +16,7 @@ registrationpage.prefixes.explanation=Surname prefixes (de, van de, etc.) if any
 registrationpage.surname.explanation=Your lastname.
 registrationpage.password.explanation=A secret, meaningless word or phrase with which you can login in the future. Minimum length is 6.
 registrationpage.confirmPassword.explanation=Repeat of the password to be sure you typed it correctly.
-registrationpage.email.explanation=E-mail address at which we can reach you.
+registrationpage.email.explanation=Official e-mail address, <b>preferable at the organization</b> you work for.
 registrationpage.mail_subject=Complete account registration.
 
 registrationpage.organization.explanation=

--- a/src/main/java/nl/knaw/dans/dccd/web/authn/RegistrationPage_de.properties
+++ b/src/main/java/nl/knaw/dans/dccd/web/authn/RegistrationPage_de.properties
@@ -16,7 +16,7 @@ registrationpage.prefixes.explanation=Nachname Präfixe (de, van de, etc.), sofer
 registrationpage.surname.explanation=Ihr Nachname.
 registrationpage.password.explanation=Ein Geheimnis, bedeutungsloses Wort oder eine Phrase, mit der Sie in Zukunft anmelden können. Mindestaufenthalt beträgt 6.
 registrationpage.confirmPassword.explanation=Wiederholung des Passwortes zu sein, dass Sie es richtig schrieben.
-registrationpage.email.explanation=E-Mail-Adresse, unter der wir Sie erreichen können.
+registrationpage.email.explanation=Offizielle E-Mail-Adresse, <b>vorzugsweise der Organisation</b>, für die Sie arbeiten.
 registrationpage.mail_subject=Komplett verändern Registrierung.
 
 registrationpage.organization.explanatio =

--- a/src/main/java/nl/knaw/dans/dccd/web/authn/RegistrationPage_fr.properties
+++ b/src/main/java/nl/knaw/dans/dccd/web/authn/RegistrationPage_fr.properties
@@ -16,7 +16,7 @@ registrationpage.prefixes.explanation=préfixes Nom (de, van de, etc) le cas éché
 registrationpage.surname.explanation=Votre nom.
 registrationpage.password.explanation=Un secret, mot vide de sens ou une phrase avec laquelle vous pouvez vous connecter à l'avenir. Durée minimale est de 6.
 registrationpage.confirmPassword.explanation=Répétez le mot de passe pour être sûr que vous avez tapé correctement.
-registrationpage.email.explanation=adresse E-mail à laquelle nous pouvons vous joindre.
+registrationpage.email.explanation=Adresse électronique officielle, <b>préférablement dans l'organisation</b> pour laquelle vous travaillez.
 registrationpage.mail_subject=inscription en compte complet.
 
 registrationpage.organization.explanation=

--- a/src/main/java/nl/knaw/dans/dccd/web/authn/RegistrationPage_nl.properties
+++ b/src/main/java/nl/knaw/dans/dccd/web/authn/RegistrationPage_nl.properties
@@ -16,7 +16,7 @@ registrationpage.prefixes.explanation=Achternaam voorvoegsels (DE, Van de, etc.)
 registrationpage.surname.explanation=Uw achternaam.
 registrationpage.password.explanation=Een geheim, betekenisloos woord of woordgroep waarmee u kunt inloggen in de toekomst. Minimum lengte is 6.
 registrationpage.confirmPassword.explanation=Herhaling van het wachtwoord om er zeker van dat het juist getyped is.
-registrationpage.email.explanation=E-mail adres waarop wij u kunnen bereiken.
+registrationpage.email.explanation=Officiële e-mail adres, <b>bij voorkeur van de organisatie</b> waarvoor u werkzaam bent.
 registrationpage.mail_subject=Complete registratie van uw account.
 
 registrationpage.organization.explanation=

--- a/src/main/java/nl/knaw/dans/dccd/web/authn/UserInfoEditPanel.html
+++ b/src/main/java/nl/knaw/dans/dccd/web/authn/UserInfoEditPanel.html
@@ -58,7 +58,7 @@
         <tr>
             <td><label for="email"><wicket:message key="user.email">Email</wicket:message></label><span class="required">*</span></td>
             <td><input id="email" type="text" wicket:id="email" /></td>
-            <td><wicket:message key="registrationpage.email.explanation">explanation</wicket:message></td>
+            <td><wicket:message key="email.explanation">explanation</wicket:message></td>
         </tr>
 
        <!-- NOTE: copy from the RegsitrationPage ! -->

--- a/src/main/java/nl/knaw/dans/dccd/web/authn/UserInfoEditPanel.properties
+++ b/src/main/java/nl/knaw/dans/dccd/web/authn/UserInfoEditPanel.properties
@@ -1,3 +1,0 @@
-#userinfoeditpanel.update=Save
-#userinfoeditpanel.cancel=Cancel
-registrationpage.email.explanation=explanation


### PR DESCRIPTION
fixing #13 
@petebrew 

registrationpage.email.explanation changed in
RegistrationPage.properties and all the language versions...

Official e-mail address, <b>preferable at the organization</b> you work for.
Officiële e-mail adres, <b>bij voorkeur van de organisatie</b> waarvoor u werkzaam bent.
Offizielle E-Mail-Adresse, <b>vorzugsweise der Organisation</b>, für die Sie arbeiten.
Adresse électronique officielle, <b>préférablement dans l'organisation</b> pour laquelle vous travaillez.

