### PR TITLE
Fixing NPE when showing dataset as search result with an empty project identifier

### DIFF
--- a/src/main/java/nl/knaw/dans/dccd/web/search/DccdSearchResultExplorePanel.java
+++ b/src/main/java/nl/knaw/dans/dccd/web/search/DccdSearchResultExplorePanel.java
@@ -507,7 +507,9 @@ public abstract class DccdSearchResultExplorePanel extends SearchPanel
 		// NOTE we always show the ProjectId because the ObjectId is incorrectly indexed 
 		// But also the project ID is forced to be unique for archived/published projects
 		// 
-		identifierStr = dccdHit.getTridasProjectIdentifier();
+		if (dccdHit.hasTridasProjectIdentifier())
+			identifierStr = dccdHit.getTridasProjectIdentifier();
+
 		// Add domain
 		String domainStr = "";
 		if (dccdHit.hasTridasProjectIdentifierDomain()) 

--- a/src/main/java/nl/knaw/dans/dccd/web/search/DccdSearchResultPanel.java
+++ b/src/main/java/nl/knaw/dans/dccd/web/search/DccdSearchResultPanel.java
@@ -819,7 +819,9 @@ public abstract class DccdSearchResultPanel extends SearchPanel
 		// NOTE we always show the ProjectId because the ObjectId is incorrectly indexed 
 		// But also the project ID is forced to be unique for archived/published projects
 		// 
-		identifierStr = dccdHit.getTridasProjectIdentifier();
+		if (dccdHit.hasTridasProjectIdentifier())
+			identifierStr = dccdHit.getTridasProjectIdentifier();
+
 		// Add domain
 		String domainStr = "";
 		if (dccdHit.hasTridasProjectIdentifierDomain()) 

--- a/src/main/java/nl/knaw/dans/dccd/web/search/LocationSearchResultPanel.java
+++ b/src/main/java/nl/knaw/dans/dccd/web/search/LocationSearchResultPanel.java
@@ -378,7 +378,9 @@ public abstract class LocationSearchResultPanel extends SearchPanel
 		// NOTE we always show the ProjectId because the ObjectId is incorrectly indexed 
 		// But also the project ID is forced to be unique for archived/published projects
 		// 
-		identifierStr = dccdHit.getTridasProjectIdentifier();
+		if (dccdHit.hasTridasProjectIdentifier())
+			identifierStr = dccdHit.getTridasProjectIdentifier();
+
 		// Add domain
 		String domainStr = "";
 		if (dccdHit.hasTridasProjectIdentifierDomain()) 

--- a/src/main/java/nl/knaw/dans/dccd/web/search/PeriodSearchResultPanel.java
+++ b/src/main/java/nl/knaw/dans/dccd/web/search/PeriodSearchResultPanel.java
@@ -314,7 +314,9 @@ public abstract class PeriodSearchResultPanel extends SearchPanel
 		// NOTE we always show the ProjectId because the ObjectId is incorrectly indexed 
 		// But also the project ID is forced to be unique for archived/published projects
 		// 
-		identifierStr = dccdHit.getTridasProjectIdentifier();
+		if (dccdHit.hasTridasProjectIdentifier())
+			identifierStr = dccdHit.getTridasProjectIdentifier();
+
 		// Add domain
 		String domainStr = "";
 		if (dccdHit.hasTridasProjectIdentifierDomain()) 


### PR DESCRIPTION
When a project is uploaded that has an empty project identifier, the upload does work, but when the 'MyProjects' is shown (search result) we get an Null Pointer Exception and get redirected to an error page. The user cannot see the 'MyProjectes' page anymore because of this error. 

The fix now tests for the existence of the identifier before constructing the message it wil display on the map and or timeline. 